### PR TITLE
docs: upstream adaptation — triage 15 page changes, refresh baseline

### DIFF
--- a/docs/anthropic-source-map.md
+++ b/docs/anthropic-source-map.md
@@ -3,7 +3,7 @@
 This document maps every StoryForge capability to the official Anthropic documentation
 that justifies or informs its design.
 
-Last audited: 2026-04-26
+Last audited: 2026-05-01
 
 ## Capability Classification
 
@@ -89,6 +89,9 @@ Each StoryForge capability is classified as one of:
 | `mcpServers` scoped to a subagent | Native | Subagents docs: mcpServers field |
 | Automatic delegation based on description | Native | Subagents docs: automatic delegation |
 | Subagents cannot spawn other subagents | Native | Subagents docs: no nested subagents |
+| `Agent(agent1, agent2)` tool syntax to restrict spawnable agents | Native | Subagents docs: control spawnable agent types |
+| `CLAUDE_CODE_SUBAGENT_MODEL` env var to override subagent model | Native | Subagents docs: model resolution order |
+| `agent-memory/` directory for subagent persistent memory | Native | Subagents docs: memory scope field |
 | portfolio-orchestrator as primary orchestrator | Convention | StoryForge convention |
 | Specialist agents (planner, implementer, etc.) | Convention | StoryForge convention |
 | Agile enforcement in agent prompts | Convention | StoryForge convention |
@@ -113,10 +116,13 @@ Each StoryForge capability is classified as one of:
 | `paths` for glob-based auto-activation | Native | Skills docs: paths field |
 | `Skill(name)` / `Skill(name *)` permission rule syntax | Native | Permissions docs: Skill tool rules |
 | `Agent(AgentName)` permission rule syntax for subagents | Native | Permissions docs: Agent tool rules |
+| `PowerShell(cmd *)` permission rule syntax | Native | Permissions docs: PowerShell rules |
+| `bypassPermissions` now includes protected paths as of v2.1.126 | Native | Permission modes docs: bypassPermissions v2.1.126 behavior |
 | `shell` for shell type (bash/powershell) | Native | Skills docs: shell field |
 | `$ARGUMENTS[N]` / `$N` positional arguments | Native | Skills docs: argument substitutions |
 | `${CLAUDE_SESSION_ID}` substitution variable | Native | Skills docs: session variable |
 | `${CLAUDE_SKILL_DIR}` substitution variable | Native | Skills docs: skill directory variable |
+| `${CLAUDE_EFFORT}` substitution variable | Native | Skills docs: effort-level variable |
 | Inline shell injection with `` !`command` `` | Native | Skills docs: shell injection syntax |
 | Kanban bootstrap as a skill | Convention | StoryForge convention |
 | Story writing as a skill | Convention | StoryForge convention |
@@ -126,6 +132,7 @@ Each StoryForge capability is classified as one of:
 
 | Capability | Classification | Anthropic Source |
 |---|---|---|
+| `Setup` hook event for `--init` / `--init-only` / `--maintenance` | Native | Hooks docs: Setup event |
 | `SessionStart` hook for session initialization | Native | Hooks docs: SessionStart event |
 | `PreToolUse` hook for pre-execution validation | Native | Hooks docs: PreToolUse event |
 | `PostToolUse` hook for post-execution actions | Native | Hooks docs: PostToolUse event |
@@ -167,6 +174,8 @@ Each StoryForge capability is classified as one of:
 | `$CLAUDE_ENV_FILE` for persistent env in SessionStart | Native | Hooks docs: environment variables |
 | `permissionDecision: "defer"` for Agent SDK integration | Native | Hooks docs: PreToolUse defer decision |
 | `allowedEnvVars` for HTTP hook header interpolation | Native | Hooks docs: http handler security |
+| `agent_id` / `agent_type` in hook input JSON (subagent context) | Native | Hooks docs: subagent hook input fields |
+| `asyncRewake` flag for background hook with wakeup on exit code 2 | Native | Hooks docs: asyncRewake field |
 | Session-start context injection | Convention | StoryForge convention using native SessionStart |
 | Agile discipline enforcement via hooks | Convention | StoryForge convention using native hooks |
 
@@ -219,6 +228,30 @@ Each StoryForge capability is classified as one of:
 | `--append-system-prompt` for additional context | Native | CLI docs: append-system-prompt flag |
 | `--bare` for minimal startup | Native | CLI docs: --bare flag |
 | `--worktree` for parallel sessions | Native | CLI docs: --worktree flag |
+| `--agents` flag for CLI-defined subagents | Native | CLI docs: --agents flag |
+| `--allowedTools` / `--disallowedTools` flags | Native | CLI docs: tool allow/deny flags |
+| `--effort` flag for session effort level | Native | CLI docs: --effort flag |
+| `--max-turns` flag for turn limits | Native | CLI docs: --max-turns flag |
+| `--max-budget-usd` flag for budget cap | Native | CLI docs: --max-budget-usd flag |
+| `--output-format` flag (text/json/stream-json) | Native | CLI docs: --output-format flag |
+| `--json-schema` flag for structured output | Native | CLI docs: --json-schema flag |
+| `--system-prompt` / `--system-prompt-file` flags | Native | CLI docs: system prompt flags |
+| `--resume` / `--continue` session flags | Native | CLI docs: resume/continue flags |
+| `--from-pr` to resume PR-linked sessions | Native | CLI docs: --from-pr flag |
+| `--name` / `-n` flag for session naming | Native | CLI docs: --name flag |
+| `--tools` flag to restrict built-in tools | Native | CLI docs: --tools flag |
+| `--setting-sources` flag for scoped settings | Native | CLI docs: --setting-sources flag |
+| `--settings` flag for additional settings | Native | CLI docs: --settings flag |
+| `--mcp-config` / `--strict-mcp-config` flags | Native | CLI docs: MCP config flags |
+| `--plugin-dir` flag for session plugins | Native | CLI docs: --plugin-dir flag |
+| `claude install` for binary install/reinstall | Native | CLI docs: install command |
+| `claude agents` to list configured subagents | Native | CLI docs: agents command |
+| `claude project purge` to clear project state | Native | CLI docs: project purge command |
+| `claude auto-mode defaults` to inspect classifier rules | Native | CLI docs: auto-mode command |
+| `--include-hook-events` for hook event streaming | Native | CLI docs: --include-hook-events flag |
+| `--exclude-dynamic-system-prompt-sections` for cache reuse | Native | CLI docs: --exclude-dynamic-system-prompt-sections flag |
+| `--fork-session` to create new session on resume | Native | CLI docs: --fork-session flag |
+| `--fallback-model` for overload fallback | Native | CLI docs: --fallback-model flag |
 | Install/bootstrap scripts using CLI | Convention | StoryForge convention using native CLI |
 
 ## Models & Runtime Modes

--- a/docs/upstream/baseline-hashes.json
+++ b/docs/upstream/baseline-hashes.json
@@ -1,91 +1,91 @@
 {
   "agent-teams": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "483a942bc4b876c1ddda9ca1cbdd2b688ea33af5440fbd3aa82116952842b427",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "c84564077ea9c8d4eb3023a26fbca93dd2a48cc77090340802c45492e3a82b1d",
     "name": "Agent Teams",
     "url": "https://code.claude.com/docs/en/agent-teams"
   },
   "best-practices": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "b1a640a0390db010f5254a289d0671c8260b13831600ad3e3c289ea1cd628980",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "e13b71be2cba72ac4d42d0e7c180e030651dbee8f2e798f0ffe20a0d64c35952",
     "name": "Best Practices",
     "url": "https://code.claude.com/docs/en/best-practices"
   },
   "cli-reference": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "4ccdb8ca878cf587eaaf0bace04c74b58e52e79934f9c6c70797b1ecd9f4ba0c",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "dc57a3ea2be15d9cbfed27659fe6809b5bb8a98efb01b66072fd7ff1c276dc48",
     "name": "CLI Reference",
     "url": "https://code.claude.com/docs/en/cli-reference"
   },
   "common-workflows": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "da46d515260fe14d7a364cc972a8d2e04c225e68db29ffc2e67a520be2e432d3",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "14d113b0228c98cd74c853eff7d23ffdc2269c3f9edebb060c9228e4aa87a3ec",
     "name": "Common Workflows",
     "url": "https://code.claude.com/docs/en/common-workflows"
   },
   "github-actions": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "9d356cd840efe75c9f699fc826b836c2df12b19817ad8c5772fa6670b86b9202",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "85f55a0ad0f4f3a6db8f12c8d684a066f39c934c1be0ab5ed7726a2e4ffd4e81",
     "name": "GitHub Actions",
     "url": "https://code.claude.com/docs/en/github-actions"
   },
   "headless": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "d2f9deae8a037a912943f825b32d12090699959bcb5ccefe89a6e77bc4763753",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "a5f99d32e6465dc346da0ac02d223112e43be35210cbd91a9a3d22f9565c9964",
     "name": "Headless Mode",
     "url": "https://code.claude.com/docs/en/headless"
   },
   "hooks": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "005a2a1a5dfce96b948f94ef10a66e83566358296f99c8ba3700b58c6ad9cf12",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "746ce6cf63e829c3ded2ea7143e306176adb3a6b77c4434bb0a8424007047a4c",
     "name": "Hooks",
     "url": "https://code.claude.com/docs/en/hooks"
   },
   "mcp": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "d225e4e45cc3d23bfc20c85a6a7734339ba6c23fedf7490a7cb93a3b811c29b3",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "cc849e21f4ca6d4515853d35a4c58d5f4aafb35fe0e0d1e65db98a96dff5eb3d",
     "name": "MCP",
     "url": "https://code.claude.com/docs/en/mcp"
   },
   "memory": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "bcd4c1ae7baa45091ab3ca87d3604eb962274634c22772e7af437afd8332a07e",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "41728cf159cd31232d6ffb6e8c07ed8dfb99f2ec0b4d4681d6bfef4b4a90ec2d",
     "name": "Memory & CLAUDE.md",
     "url": "https://code.claude.com/docs/en/memory"
   },
   "permission-modes": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "cb057fb4e04f684df9b34626f493557eb4a5f5f4c7fbedcb8e6f67e49beac23b",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "d4c54bffa4376cf787b872a214916d6ce97e402a3563e52a1407e145398b0485",
     "name": "Permission Modes",
     "url": "https://code.claude.com/docs/en/permission-modes"
   },
   "permissions": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "5f0562b7bc5d64340001a9d535924b8a7ec4e08ca70ff003010ab435ecdb6a65",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "722e1fa38ece3e316003f9fe3fe0059c3a17515b98d706c661a1e1c0cbd05283",
     "name": "Permissions",
     "url": "https://code.claude.com/docs/en/permissions"
   },
   "scheduled-tasks": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "81366622b0a9f2db4f1695d182d259253c7bdb0d34e2344ace5e70817c5a975c",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "2d2bf19bff0907ada428043100582447dc6383f6637a5ce8b9a7fcc49ff3f195",
     "name": "Scheduled Tasks",
     "url": "https://code.claude.com/docs/en/scheduled-tasks"
   },
   "settings": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "eed4a83258ade707951a0c39c324a4c4b87be66ba89b5a292a33ba0ca7efbb99",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "bb821a805984b4370b9e99cc84bb9f5f93a65a3755aee1bdd774938583a3793e",
     "name": "Settings",
     "url": "https://code.claude.com/docs/en/settings"
   },
   "skills": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "ca38d782bced825bbf657aeee6fb7537e3fe755af98a38120a319006713d20e3",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "eb9b95fac1e45eed34bf42845b91e035bbadb9ad2f297aa5908deabd46d0bcfd",
     "name": "Skills",
     "url": "https://code.claude.com/docs/en/skills"
   },
   "sub-agents": {
-    "checked": "2026-04-27T00:46:59Z",
-    "hash": "daeba679471ef9dbff85c8212ad94caa0287c882f7df5d467eaff8353af75399",
+    "checked": "2026-05-01T20:44:12Z",
+    "hash": "e3722834310347282311231bc416eee0cec1ef358721f1d1f0cc5dac0c300f2f",
     "name": "Subagents",
     "url": "https://code.claude.com/docs/en/sub-agents"
   }

--- a/docs/upstream/doc-index.md
+++ b/docs/upstream/doc-index.md
@@ -2,27 +2,27 @@
 
 Official documentation sources used by StoryForge, with last-verified dates.
 
-Last updated: 2026-04-26
+Last updated: 2026-05-01
 
 ## Primary Documentation
 
 | Document | URL | Last Verified | StoryForge Impact |
 |---|---|---|---|
-| Memory & CLAUDE.md | https://code.claude.com/docs/en/memory | 2026-04-26 | Global + Project CLAUDE.md templates, auto memory |
-| Subagents | https://code.claude.com/docs/en/sub-agents | 2026-04-26 | Agent strategy, all agent definitions |
-| Hooks | https://code.claude.com/docs/en/hooks | 2026-04-26 | Hook configuration, enforcement layer |
-| Skills | https://code.claude.com/docs/en/skills | 2026-04-26 | All skill definitions |
-| Settings | https://code.claude.com/docs/en/settings | 2026-04-26 | User + project settings templates |
-| CLI Reference | https://code.claude.com/docs/en/cli-reference | 2026-04-17 | Scripts, install, bootstrap |
-| Permission Modes | https://code.claude.com/docs/en/permission-modes | 2026-04-17 | Safety policy, default modes |
-| Permissions | https://code.claude.com/docs/en/permissions | 2026-04-26 | Permission rules in templates |
-| Common Workflows | https://code.claude.com/docs/en/common-workflows | 2026-04-26 | Workflow patterns |
-| Best Practices | https://code.claude.com/docs/en/best-practices | 2026-04-15 | CLAUDE.md content guidance |
-| Headless Mode | https://code.claude.com/docs/en/headless | 2026-04-26 | Non-interactive scripts |
-| GitHub Actions | https://code.claude.com/docs/en/github-actions | 2026-04-17 | CI/CD integration |
-| Agent Teams | https://code.claude.com/docs/en/agent-teams | 2026-04-26 | Multi-agent patterns |
-| MCP | https://code.claude.com/docs/en/mcp | 2026-04-26 | MCP server configuration |
-| Scheduled Tasks | https://code.claude.com/docs/en/scheduled-tasks | 2026-04-26 | Cron, scheduled agents, /loop |
+| Memory & CLAUDE.md | https://code.claude.com/docs/en/memory | 2026-05-01 | Global + Project CLAUDE.md templates, auto memory |
+| Subagents | https://code.claude.com/docs/en/sub-agents | 2026-05-01 | Agent strategy, all agent definitions |
+| Hooks | https://code.claude.com/docs/en/hooks | 2026-05-01 | Hook configuration, enforcement layer |
+| Skills | https://code.claude.com/docs/en/skills | 2026-05-01 | All skill definitions |
+| Settings | https://code.claude.com/docs/en/settings | 2026-05-01 | User + project settings templates |
+| CLI Reference | https://code.claude.com/docs/en/cli-reference | 2026-05-01 | Scripts, install, bootstrap |
+| Permission Modes | https://code.claude.com/docs/en/permission-modes | 2026-05-01 | Safety policy, default modes |
+| Permissions | https://code.claude.com/docs/en/permissions | 2026-05-01 | Permission rules in templates |
+| Common Workflows | https://code.claude.com/docs/en/common-workflows | 2026-05-01 | Workflow patterns |
+| Best Practices | https://code.claude.com/docs/en/best-practices | 2026-05-01 | CLAUDE.md content guidance |
+| Headless Mode | https://code.claude.com/docs/en/headless | 2026-05-01 | Non-interactive scripts |
+| GitHub Actions | https://code.claude.com/docs/en/github-actions | 2026-05-01 | CI/CD integration |
+| Agent Teams | https://code.claude.com/docs/en/agent-teams | 2026-05-01 | Multi-agent patterns |
+| MCP | https://code.claude.com/docs/en/mcp | 2026-05-01 | MCP server configuration |
+| Scheduled Tasks | https://code.claude.com/docs/en/scheduled-tasks | 2026-05-01 | Cron, scheduled agents, /loop |
 
 ## Verification Schedule
 

--- a/docs/upstream/release-watch.md
+++ b/docs/upstream/release-watch.md
@@ -141,3 +141,38 @@ Action: Updated verification dates to 2026-04-26. Source map updated with 7 new 
 Baseline refreshed. No template/agent/hook/skill changes required. No adaptation Stories
 created.
 
+---
+
+### 2026-05-01: 15 page changes triaged (Issue #22)
+
+All 15 changes are additive or clarifications — no breaking changes to StoryForge templates,
+agents, hooks, or skills. The GitHub Actions page documents a v1.0 GA with breaking changes
+from beta; StoryForge does not ship a GitHub Actions workflow so no adaptation is needed.
+
+| Page | Impact | Notes |
+|---|---|---|
+| Memory & CLAUDE.md | No Impact | New CLAUDE.md loading detail (HTML comment stripping, sub-directory lazy load), new `/memory` command UX, `CLAUDE_CODE_NEW_INIT=1` env var for interactive `/init`. All additive; already covered in source map. |
+| Subagents | Docs Impact | New `Agent(agent1, agent2)` tool-list syntax for coordinator agents restricting which subagents can be spawned. `CLAUDE_CODE_SUBAGENT_MODEL` env var for model override precedence. Subagent `agent-memory/` directory for `memory` field. Source map updated. |
+| Hooks | Docs Impact | New `Setup` event (for `--init`, `--init-only`, `--maintenance`). `asyncRewake` field documented explicitly. `agent_id` / `agent_type` in subagent hook input. Source map updated with these 3 entries. |
+| Skills | Docs Impact | New `${CLAUDE_EFFORT}` substitution variable. `disableSkillShellExecution` policy setting documented. Live change detection (no restart needed for edits). Source map updated. |
+| Settings | No Impact | Expanded key list (sandbox, plugins, channels, voice, UX prefs). All additive; not adopted by StoryForge templates. |
+| CLI Reference | Docs Impact | Substantially expanded: new commands (`claude install`, `claude agents`, `claude project purge`, `claude auto-mode defaults`, `claude remote-control`, `claude setup-token`, `claude ultrareview`); many new flags (`--agents`, `--allowedTools`, `--effort`, `--max-turns`, `--max-budget-usd`, `--output-format`, `--json-schema`, `--system-prompt`, `--resume`, `--from-pr`, `--name`, `--tools`, `--setting-sources`, `--settings`, `--mcp-config`, `--strict-mcp-config`, `--plugin-dir`, `--include-hook-events`, `--exclude-dynamic-system-prompt-sections`, `--fork-session`, `--fallback-model`). Source map updated with all CLI additions. StoryForge scripts use only `claude -p`, `--agent`, `--permission-mode`, `--bare`, `--worktree`, `--append-system-prompt` — all still valid. |
+| Permission Modes | Docs Impact | `bypassPermissions` as of v2.1.126 now also allows writes to protected paths (`.git`, `.vscode`, `.idea`, `.husky`, `.claude`). `acceptEdits` auto-approves PowerShell commands. Explicit protected-paths and protected-files tables documented. Source map updated. StoryForge templates do not use `bypassPermissions`; no adaptation required. |
+| Permissions | Docs Impact | `PowerShell(cmd *)` permission rule syntax documented. Process-wrapper stripping list (timeout/time/nice/nohup/stdbuf, bare xargs) and exec-wrapper non-approvability (`watch`, `setsid`, `flock`) documented. Source map updated. |
+| Common Workflows | No Impact | New scheduling comparison table (Routines/Desktop/`/loop`/GitHub Actions). `Ctrl+G` for in-editor plan editing. Session picker keyboard shortcuts. Worker/Reviewer parallel pattern example. All referenced mechanisms already in source map. |
+| Best Practices | No Impact | Page substantially rewritten with richer guidance (context management, verification, Plan Mode workflow, subagent use, session management, parallel sessions). All recommendations reference native features already in source map. No new capabilities introduced. |
+| Headless Mode | No Impact | Page rebranded "Run Claude Code programmatically." `system/plugin_install` events documented alongside `system/init` and `system/api_retry`. `--bare` as future default for `-p` noted. All additive; source map already covers Agent SDK framing. |
+| GitHub Actions | No Impact | v1.0 GA breaking changes from beta documented (renamed inputs, `mode` removed, `claude_args` passthrough). StoryForge does not ship a GitHub Actions workflow; no adaptation required. |
+| Agent Teams | No Impact | `TeammateIdle` hook, `TaskCreated`/`TaskCompleted` hooks, `teammateMode` setting all already in source map. Page content unchanged from prior baseline. |
+| MCP | No Impact | Core config schema unchanged. Registry UI component is React rendering noise. `allowedMcpServers`/`deniedMcpServers` managed settings already noted under Settings. |
+| Scheduled Tasks | No Impact | Scheduling comparison table added. All mechanisms (`/loop`, `CronCreate/List/Delete`, `loop.md`, jitter, 7-day expiry) match prior source map entries. |
+
+New source map entries added: `${CLAUDE_EFFORT}` skill variable, `Setup` hook event,
+`agent_id`/`agent_type` hook input fields, `asyncRewake` hook flag, `Agent(a,b)` tools syntax,
+`CLAUDE_CODE_SUBAGENT_MODEL` env var, `agent-memory/` subagent memory directory,
+`PowerShell()` permission rule, `bypassPermissions` v2.1.126 protected-path behavior,
+25 CLI commands and flags now documented in source map.
+
+Action: Updated verification dates to 2026-05-01. Source map updated with ~30 additive entries.
+Baseline refreshed. No template/agent/hook/skill changes required. No adaptation Stories created.
+

--- a/docs/upstream/reports/upstream-report-2026-05-01.md
+++ b/docs/upstream/reports/upstream-report-2026-05-01.md
@@ -1,0 +1,122 @@
+# Upstream Documentation Change Report
+
+**Generated**: 2026-05-01T20:39:50Z
+**Pages checked**: 15
+**Changes detected**: 15
+**New pages**: 0
+**Unreachable**: 0
+**Unchanged**: 0
+
+## Changes Detected
+
+### Memory & CLAUDE.md
+
+- **URL**: https://code.claude.com/docs/en/memory
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: CLAUDE.md templates, rules files, auto memory
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Subagents
+
+- **URL**: https://code.claude.com/docs/en/sub-agents
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: agent definitions, agent frontmatter
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Hooks
+
+- **URL**: https://code.claude.com/docs/en/hooks
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: settings.json hooks, enforcement layer
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Skills
+
+- **URL**: https://code.claude.com/docs/en/skills
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: skill definitions, SKILL.md format
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Settings
+
+- **URL**: https://code.claude.com/docs/en/settings
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: settings.json templates, permission rules
+- **Action required**: Review the page and determine impact on StoryForge
+
+### CLI Reference
+
+- **URL**: https://code.claude.com/docs/en/cli-reference
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: scripts, CLI usage patterns
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Permission Modes
+
+- **URL**: https://code.claude.com/docs/en/permission-modes
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: safety policy, default modes
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Permissions
+
+- **URL**: https://code.claude.com/docs/en/permissions
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: permission rules, deny patterns
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Common Workflows
+
+- **URL**: https://code.claude.com/docs/en/common-workflows
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: workflow documentation
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Best Practices
+
+- **URL**: https://code.claude.com/docs/en/best-practices
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: CLAUDE.md guidance
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Headless Mode
+
+- **URL**: https://code.claude.com/docs/en/headless
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: scripts, CI integration
+- **Action required**: Review the page and determine impact on StoryForge
+
+### GitHub Actions
+
+- **URL**: https://code.claude.com/docs/en/github-actions
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: CI workflow
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Agent Teams
+
+- **URL**: https://code.claude.com/docs/en/agent-teams
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: multi-agent patterns
+- **Action required**: Review the page and determine impact on StoryForge
+
+### MCP
+
+- **URL**: https://code.claude.com/docs/en/mcp
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: MCP configuration
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Scheduled Tasks
+
+- **URL**: https://code.claude.com/docs/en/scheduled-tasks
+- **Last checked**: 2026-04-27T00:46:59Z
+- **Impact areas**: cron configuration, monitoring
+- **Action required**: Review the page and determine impact on StoryForge
+
+### Recommended Actions
+
+1. Review each changed page manually
+2. Classify impact using `docs/upstream/release-watch.md` categories
+3. Create Stories for required adaptations using `/story-write`
+4. Update baseline with: `python scripts/upstream_monitor.py --update-baseline`


### PR DESCRIPTION
Closes #22

## Summary
- Triages 15 upstream documentation changes detected by the daily monitor (2026-04-29 → 2026-05-01)
- All changes are additive or clarifications — no breaking changes to StoryForge templates, agents, hooks, or skills
- Updates ~30 additive entries in the source map and refreshes baseline + verification dates to 2026-05-01

## Triage
| Page | Impact |
|---|---|
| Memory & CLAUDE.md | No Impact |
| Subagents | Docs Impact (Agent(a,b) syntax, CLAUDE_CODE_SUBAGENT_MODEL, agent-memory/) |
| Hooks | Docs Impact (Setup event, asyncRewake, agent_id/agent_type) |
| Skills | Docs Impact (${CLAUDE_EFFORT}, disableSkillShellExecution, live reload) |
| Settings | No Impact |
| CLI Reference | Docs Impact (~25 new commands/flags; existing StoryForge usage still valid) |
| Permission Modes | Docs Impact (bypassPermissions v2.1.126 protected paths) |
| Permissions | Docs Impact (PowerShell() rule, process-wrapper stripping) |
| Common Workflows | No Impact |
| Best Practices | No Impact |
| Headless Mode | No Impact |
| GitHub Actions | No Impact (StoryForge ships no GHA workflow) |
| Agent Teams | No Impact |
| MCP | No Impact |
| Scheduled Tasks | No Impact |

## Test plan
- [ ] `bash scripts/validate_templates.sh` passes
- [ ] `python -m pytest tests/ -v` passes
- [ ] Source map renders correctly on GitHub