### PR TITLE
ci: support Claude subscription auth (CLAUDE_CODE_OAUTH_TOKEN) in upstream-triage

### DIFF
--- a/.github/workflows/upstream-triage.yml
+++ b/.github/workflows/upstream-triage.yml
@@ -44,14 +44,18 @@ jobs:
     name: Triage upstream changes with Claude
 
     env:
+      # Auth: prefer CLAUDE_CODE_OAUTH_TOKEN (Claude subscription) and fall
+      # back to ANTHROPIC_API_KEY if present. Pro/Max users generate the OAuth
+      # token by running `claude setup-token` locally.
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
 
     steps:
-      - name: Validate API key is configured
+      - name: Validate Claude credentials are configured
         run: |
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "::error::ANTHROPIC_API_KEY secret is not set. Add it under Settings > Secrets and variables > Actions."
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::No Claude credentials found. Set either CLAUDE_CODE_OAUTH_TOKEN (run \`claude setup-token\` locally on a Pro/Max account) or ANTHROPIC_API_KEY under Settings > Secrets and variables > Actions."
             exit 1
           fi
 
@@ -211,7 +215,12 @@ jobs:
         timeout-minutes: 30
         run: |
           set -euo pipefail
-          claude --bare -p "$(cat triage_prompt.md)" \
+          # Note: we don't pass --bare. Bare mode skips OAuth/keychain reads
+          # and requires ANTHROPIC_API_KEY; we want CLAUDE_CODE_OAUTH_TOKEN to
+          # work so subscription users can run this workflow without an API
+          # key. The repo has no project-level .claude/settings.json, hooks,
+          # MCP config, or plugins, so non-bare mode loads nothing surprising.
+          claude -p "$(cat triage_prompt.md)" \
             --permission-mode acceptEdits \
             --allowedTools "Read,Edit,Write,Glob,Grep,WebFetch,Bash(python *),Bash(git diff *),Bash(git status *),Bash(ls *),Bash(cat *)" \
             --append-system-prompt-file .claude/agents/upstream-watch.md \


### PR DESCRIPTION
## Summary

Original workflow required `ANTHROPIC_API_KEY`. Pro/Max subscribers don't have one without a separate API plan. This PR adds support for `CLAUDE_CODE_OAUTH_TOKEN` — the subscription-friendly auth path documented by the official [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action).

## Changes

- Workflow accepts **either** `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`. Validation step fails fast if neither is set.
- Drops `--bare` from the `claude -p` invocation. Bare mode skips OAuth/keychain reads and requires `ANTHROPIC_API_KEY` explicitly. Non-bare mode honors the OAuth token env var, and this repo has no project-level `.claude/settings.json`, hooks, MCP config, or plugins to load, so non-bare adds no surprises in CI.

## How to use the subscription path

On any machine where you're logged in to Claude Code with a Pro/Max account:

```bash
claude setup-token
```

Copy the printed token, then in the repo: **Settings → Secrets and variables → Actions → New repository secret**:
- Name: `CLAUDE_CODE_OAUTH_TOKEN`
- Value: *the token*

That's it. The next upstream issue opens → workflow runs → triage PR appears.

## Test plan

- [ ] Generate a token with `claude setup-token` and add it as `CLAUDE_CODE_OAUTH_TOKEN` secret
- [ ] Trigger via `workflow_dispatch` with a known issue number to validate end-to-end
- [ ] Confirm the produced PR matches prior triage PR format
- [ ] If desired, also test API-key fallback by setting `ANTHROPIC_API_KEY` (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)